### PR TITLE
Fixed rspec, updated to 3.0, removed , minimal failed case spec

### DIFF
--- a/constantizer.gemspec
+++ b/constantizer.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '< 3.0'
+  spec.add_development_dependency 'rspec', '>= 3.0'
   spec.add_development_dependency 'pry'
 end

--- a/lib/constantizer.rb
+++ b/lib/constantizer.rb
@@ -31,3 +31,4 @@ require('constantizer/integration/rails') if defined?(::Rails)
 
 # add sinatra integration
 require('constantizer/integration/sinatra') if defined?(::Sinatra)
+

--- a/spec/constantizer_spec.rb
+++ b/spec/constantizer_spec.rb
@@ -1,14 +1,21 @@
 require 'spec_helper'
 
 describe Constantizer do
-  context 'given the templates directory' do
-    before do
-      described_class.load!(File.expand_path('lib/constantizer/templates'))
-    end
+  let(:file) { 'lib/constantizer/templates' }
 
+  before do
+    described_class.load!(File.expand_path(file))
+  end
+
+  context 'given the templates directory' do
     it 'should initialize the constants' do
-      expect(CURRENCIES).to have(2).item
+      expect(CURRENCIES.count).to eq(2)
       expect(DEFAULT_CURRENCY).to eq('USD')
     end
+  end
+
+  context 'given the unexisted directory' do
+    let(:file) { 'who_are_you' }
+    it { expect{CURRENCIES}.to raise_error(NameError) }
   end
 end


### PR DESCRIPTION
@baraabourghli , 

Its interesting approach, the constant is set on the Kernel layer. Wondering if its a way to unload the whole constant, on reload ?

Maybe best to  add a constant cleanup after reload/load?

e.g:

C.load 'toto'
C.load 'tata' (Kernel still has the `toto` constants)

